### PR TITLE
Fix the K8s URL for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To use these guides you need the following pre-requisites:
 4. An editor with Java support (e.g. Eclipse, VS Code, IntelliJ)
 5. Docker & Kubernetes:
    1. Windows: https://docs.docker.com/docker-for-windows/#kubernetes 
-   2. Mac: https://docs.docker.com/docker-for-windows/#kubernetes
+   2. Mac: https://docs.docker.com/docker-for-mac/#kubernetes
    3. Linux: https://github.com/kubernetes/minikube#installation)
 6. Download latest stable Istio release (not a Pre-release): https://github.com/istio/istio/releases
 


### PR DESCRIPTION
The URL for K8s was wrong, so I fixed it. :-)
